### PR TITLE
Minor changes in reading config files and determining calib_dir

### DIFF
--- a/Pose2Sim/Pose2Sim.py
+++ b/Pose2Sim/Pose2Sim.py
@@ -146,7 +146,7 @@ def read_config_files(config):
             # Create config dictionaries for all trials of the participant
             for (root,dirs,files) in os.walk(config_dir):
                 if 'Config.toml' in files and root != config_dir:
-                    trial_config_dict = toml.load(os.path.join(root, files[0]))
+                    trial_config_dict = toml.load(os.path.join(root, "Config.toml"))
                     # deep copy, otherwise session_config_dict is modified at each iteration within the config_dicts list
                     temp_dict = deepcopy(session_config_dict)
                     temp_dict = recursive_update(temp_dict,participant_config_dict)
@@ -164,10 +164,10 @@ def read_config_files(config):
                 if 'Config.toml' in files and root != config_dir:
                     # participant
                     if determine_level(root) == 2:
-                        participant_config_dict = toml.load(os.path.join(root, files[0]))
+                        participant_config_dict = toml.load(os.path.join(root, "Config.toml"))
                     # trial 
                     elif determine_level(root) == 1: 
-                        trial_config_dict = toml.load(os.path.join(root, files[0]))
+                        trial_config_dict = toml.load(os.path.join(root, "Config.toml"))
                         # deep copy, otherwise session_config_dict is modified at each iteration within the config_dicts list
                         temp_dict = deepcopy(session_config_dict)
                         temp_dict = recursive_update(temp_dict,participant_config_dict)
@@ -204,7 +204,7 @@ def calibration(config=None):
     currentDateAndTime = datetime.now()
     
     # Run calibration
-    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if 'calib' in c.lower() ][0]
+    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if os.path.isdir(os.path.join(session_dir, c)) and 'calib' in c.lower() ][0]
     logging.info("\n\n---------------------------------------------------------------------")
     logging.info("Camera calibration")
     logging.info(f"On {currentDateAndTime.strftime('%A %d. %B %Y, %H:%M:%S')}")

--- a/Pose2Sim/personAssociation.py
+++ b/Pose2Sim/personAssociation.py
@@ -568,7 +568,7 @@ def recap_tracking(config, error=0, nb_cams_excluded=0):
     reconstruction_error_threshold = config.get('personAssociation').get('multi_person').get('reconstruction_error_threshold')
     min_affinity = config.get('personAssociation').get('multi_person').get('min_affinity')
     poseTracked_dir = os.path.join(project_dir, 'pose-associated')
-    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if 'calib' in c.lower()][0]
+    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if  os.path.isdir(os.path.join(session_dir, c)) and 'calib' in c.lower() ][0]
     calib_file = glob.glob(os.path.join(calib_dir, '*.toml'))[0] # lastly created calibration file
     
     if not multi_person:
@@ -633,7 +633,7 @@ def track_2d_all(config):
     frame_range = config.get('project').get('frame_range')
     undistort_points = config.get('triangulation').get('undistort_points')
     
-    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if 'calib' in c.lower() ][0]
+    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if os.path.isdir(os.path.join(session_dir, c)) and 'calib' in c.lower() ][0]
     try:
         calib_file = glob.glob(os.path.join(calib_dir, '*.toml'))[0] # lastly created calibration file
     except:

--- a/Pose2Sim/triangulation.py
+++ b/Pose2Sim/triangulation.py
@@ -178,7 +178,7 @@ def sort_people(Q_kpt_old, Q_kpt):
     # Compute distance between persons from one frame to another
     frame_by_frame_dist = []
     for comb in personsIDs_comb:
-        frame_by_frame_dist += [euclidean_distance(Q_kpt_old[comb[0]],Q_kpt[comb[1]])]
+        frame_by_frame_dist += [euclidean_distance(Q_kpt_old[comb[0]][:3],Q_kpt[comb[1]][:3])]
         
     # sort correspondences by distance
     minL, _, associated_tuples = min_with_single_indices(frame_by_frame_dist, personsIDs_comb)
@@ -312,7 +312,7 @@ def recap_triangulate(config, error, nb_cams_excluded, keypoints_names, cam_excl
     session_dir = os.path.realpath(os.path.join(project_dir, '..', '..'))
     # if single trial
     session_dir = os.getcwd() if not 'Config.toml' in os.listdir(session_dir) else session_dir
-    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if 'calib' in c.lower()][0]
+    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if os.path.isdir(os.path.join(session_dir, c)) and 'calib' in c.lower()][0]
     calib_file = glob.glob(os.path.join(calib_dir, '*.toml'))[0] # lastly created calibration file
     calib = toml.load(calib_file)
     cam_names = np.array([calib[c].get('name') for c in list(calib.keys())])
@@ -709,7 +709,7 @@ def triangulate_all(config):
     make_c3d = config.get('triangulation').get('make_c3d')
     frame_rate = config.get('project').get('frame_rate')
     
-    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if 'calib' in c.lower()][0]
+    calib_dir = [os.path.join(session_dir, c) for c in os.listdir(session_dir) if os.path.isdir(os.path.join(session_dir, c)) and  'calib' in c.lower()][0]
     try:
         calib_file = glob.glob(os.path.join(calib_dir, '*.toml'))[0] # lastly created calibration file
     except:


### PR DESCRIPTION
I only changed some minor things, that don't change any functions but maight prevent errors for other users.

In Pose2Sim.py, the method for loading configuration files did not work when there was a file sorted before Config.toml. It now explicitly loads the Config.toml file.

In personAssociation.py and triangulation.py, the config_dir could not be determined correctly if there was a file sorted before the directory. It now only considers directories.