### PR TITLE
remove "Mouth21"

### DIFF
--- a/Pose2Sim/skeletons.py
+++ b/Pose2Sim/skeletons.py
@@ -359,9 +359,7 @@ COCO_133 = Node("Hip", id=None, children=[
                                                                         Node("Mouth17", id=87, children=[
                                                                             Node("Mouth18", id=88, children=[
                                                                                 Node("Mouth19", id=89, children=[
-                                                                                    Node("Mouth20", id=90, children=[
-                                                                                        Node("Mouth21", id=91)
-                                                                                    ]),
+                                                                                    Node("Mouth20", id=90)
                                                                                 ]),
                                                                             ]),
                                                                         ]),


### PR DESCRIPTION
Hello Dr. David,

While testing DeepSort with COCO_133, I noticed a poor connection between the Lwrist and Mouth nodes. Upon further investigation, I realized that the face should have 68 keypoints, but the current COCO_133 in the skeleton.py contains 69. I suspect this discrepancy may have caused the issue.

To test this hypothesis, I removed the last mouth node (Mouth21). As a result, the tracking now appears to be working more reasonably!

**Current version: 69 face keypoints (Jaw1 (id=13) to Mouth21 (id=91))**
![image](https://github.com/user-attachments/assets/f3b35fcd-ef4a-4417-88b7-824a910a9c5b)

**Modified version: 68 face keypoints (Jaw1 (id=13) to Mouth20 (id=90))**
![image](https://github.com/user-attachments/assets/199c1b5b-14ca-4e1c-a273-b4f33f78fd69)

Thanks for reading!

Best regards,
HunMin Kim