### PR TITLE
Handle calibration files with extra cameras

### DIFF
--- a/Pose2Sim/common.py
+++ b/Pose2Sim/common.py
@@ -251,7 +251,7 @@ def bounding_boxes(js_file, margin_percent=0.1, around='extremities'):
     return bounding_boxes   
 
 
-def retrieve_calib_params(calib_file):
+def retrieve_calib_params(calib_file, json_pose_dirs_names=None):
     '''
     Compute projection matrices from toml calibration file.
     
@@ -273,22 +273,35 @@ def retrieve_calib_params(calib_file):
     cal_keys = [c for c in calib.keys() 
                 if c not in ['metadata', 'capture_volume', 'charuco', 'checkerboard'] 
                 and isinstance(calib[c],dict)]
+    
+    if json_pose_dirs_names is None:
+        pose_keys = cal_keys
+    else:
+        pose_keys = [name.replace('_json', '') for name in json_pose_dirs_names]
+        missing_cams = [cam for cam in pose_keys if cam not in cal_keys]
+        if missing_cams:
+            logging.error(f"The following cameras are present in the pose folders but missing in the calibration file: {missing_cams}.")
+            raise ValueError(f"The following cameras are present in the pose folders but missing in the calibration file: {missing_cams}.")
+
+
     S, K, dist, optim_K, inv_K, R, R_mat, T = [], [], [], [], [], [], [], []
-    for c, cam in enumerate(cal_keys):
+    for cam in list(cal_keys):
+        if cam not in pose_keys:
+            continue
         S.append(np.array(calib[cam]['size']))
         K.append(np.array(calib[cam]['matrix']))
         dist.append(np.array(calib[cam]['distortions']))
-        optim_K.append(cv2.getOptimalNewCameraMatrix(K[c], dist[c], [int(s) for s in S[c]], 1, [int(s) for s in S[c]])[0])
-        inv_K.append(np.linalg.inv(K[c]))
+        optim_K.append(cv2.getOptimalNewCameraMatrix(K[-1], dist[-1], [int(s) for s in S[-1]], 1, [int(s) for s in S[-1]])[0])
+        inv_K.append(np.linalg.inv(K[-1]))
         R.append(np.array(calib[cam]['rotation']))
-        R_mat.append(cv2.Rodrigues(R[c])[0])
+        R_mat.append(cv2.Rodrigues(R[-1])[0])
         T.append(np.array(calib[cam]['translation']))
     calib_params = {'S': S, 'K': K, 'dist': dist, 'inv_K': inv_K, 'optim_K': optim_K, 'R': R, 'R_mat': R_mat, 'T': T}
             
     return calib_params
 
 
-def computeP(calib_file, undistort=False):
+def computeP(calib_file, json_pose_dirs_names=None, undistort=False):
     '''
     Compute projection matrices from toml calibration file.
     
@@ -305,8 +318,20 @@ def computeP(calib_file, undistort=False):
     cal_keys = [c for c in calib.keys() 
                 if c not in ['metadata', 'capture_volume', 'charuco', 'checkerboard'] 
                 and isinstance(calib[c],dict)]
+    
+    if json_pose_dirs_names is None:
+        pose_keys = cal_keys
+    else:
+        pose_keys = [name.replace('_json', '') for name in json_pose_dirs_names]
+        missing_cams = [cam for cam in pose_keys if cam not in cal_keys]
+        if missing_cams:
+            logging.error(f"The following cameras are present in the pose folders but missing in the calibration file: {missing_cams}.")
+            raise ValueError(f"The following cameras are present in the pose folders but missing in the calibration file: {missing_cams}.")
+
     P = []
     for cam in list(cal_keys):
+        if cam not in pose_keys:
+            continue
         K = np.array(calib[cam]['matrix'])
         if undistort:
             S = np.array(calib[cam]['size'])
@@ -322,18 +347,6 @@ def computeP(calib_file, undistort=False):
         P.append(Kh @ H)
    
     return P
-
-def adapt_P_and_calib_params(P_all, calib_params_all, pose_listdirs_names):
-    P_adapted = []
-    calib_params_adapted = {k: [] for k in calib_params_all}
-    
-    for dir_name in pose_listdirs_names:
-        cam_idx = int(re.findall(r'\d+', dir_name)[-1]) - 1  # assuming camera numbering starts at 1
-        P_adapted.append(P_all[cam_idx])
-        for key in calib_params_all:
-            calib_params_adapted[key].append(calib_params_all[key][cam_idx])
-
-    return P_adapted, calib_params_adapted
 
 
 def weighted_triangulation(P_all,x_all,y_all,likelihood_all):

--- a/Pose2Sim/personAssociation.py
+++ b/Pose2Sim/personAssociation.py
@@ -47,7 +47,7 @@ from anytree.importer import DictImporter
 import logging
 
 from Pose2Sim.common import retrieve_calib_params, computeP, weighted_triangulation, \
-    reprojection, euclidean_distance, sort_stringlist_by_last_number, adapt_P_and_calib_params
+    reprojection, euclidean_distance, sort_stringlist_by_last_number
 from Pose2Sim.skeletons import *
 
 
@@ -686,10 +686,6 @@ def associate_all(config_dict):
     pose_dir = os.path.join(project_dir, 'pose')
     poseSync_dir = os.path.join(project_dir, 'pose-sync')
     poseTracked_dir = os.path.join(project_dir, 'pose-associated')
-
-    # projection matrix from toml calibration file
-    P_all = computeP(calib_file, undistort=undistort_points)
-    calib_params = retrieve_calib_params(calib_file)
         
     # selection of tracked keypoint id
     try: # from skeletons.py
@@ -736,14 +732,9 @@ def associate_all(config_dict):
     f_range = [[0,max([len(j) for j in json_files_names])] if frame_range in ('all', 'auto', []) else frame_range][0]
     n_cams = len(json_dirs_names)
 
-    # Check camera number consistency between calibration file and pose folders
-    if len(P_all) > n_cams:
-        logging.warning('The number of cameras in the calibration file is greater than the number of pose folders. Only cameras in pose folders will be considered.')
-        P_adapted, calib_params_adapted = adapt_P_and_calib_params(P_all, calib_params, json_dirs_names)
-    elif len(P_all) < n_cams:
-        raise Exception ('The number of cameras in the calibration file is less than the number of pose folders. Please match your calibration file and pose folders.')
-    else:
-        P_adapted, calib_params_adapted = P_all, calib_params
+    # projection matrix from toml calibration file
+    P = computeP(calib_file, json_dirs_names, undistort=undistort_points)
+    calib_params = retrieve_calib_params(calib_file, json_dirs_names)
 
     if not multi_person:
         logging.info('\nSingle-person analysis selected.')
@@ -774,7 +765,7 @@ def associate_all(config_dict):
             personsIDs_comb = persons_combinations(json_files_f) 
             
             # choose persons of interest and exclude cameras with bad pose estimation
-            error_proposals, proposals, Q_kpt = best_persons_and_cameras_combination(config_dict, json_files_f, personsIDs_comb, P_adapted, tracked_keypoint_id, calib_params_adapted)
+            error_proposals, proposals, Q_kpt = best_persons_and_cameras_combination(config_dict, json_files_f, personsIDs_comb, P, tracked_keypoint_id, calib_params)
 
             if not np.isinf(error_proposals):
                 error_min_tot.append(np.nanmean(error_proposals))
@@ -793,7 +784,7 @@ def associate_all(config_dict):
             cum_persons_per_view = np.cumsum(persons_per_view)
             
             # compute affinity and only keep possible matches
-            affinity = compute_affinity(all_json_data_f, calib_params_adapted, cum_persons_per_view, reconstruction_error_threshold=reconstruction_error_threshold)
+            affinity = compute_affinity(all_json_data_f, calib_params, cum_persons_per_view, reconstruction_error_threshold=reconstruction_error_threshold)
             circ_constraint = circular_constraint(cum_persons_per_view)
             affinity = affinity * circ_constraint
 


### PR DESCRIPTION
Hello !

In this pull request, I add a new helper function, adapt_P_and_calib_params(), to handle cases where the number of cameras defined in the calibration files exceeds the number of pose folders available. This function issues clear warnings and automatically adapts the calibration parameters so that only the relevant cameras are used.

The main changes are:

1. Add adapt_P_and_calib_params() to centralize the logic for aligning calibration parameters with available pose folders.
2. Update personAssociation.py and triangulation.py to call this function when loading calibration data.
3. Improve logging messages to make it explicit when some cameras from the calibration files are ignored because they have no corresponding pose folder.

This should make the pipeline more robust to inconsistent calibration/pose configurations while preserving existing behavior when the inputs are consistent.