### PR TITLE
Filter out persons with all NaN keypoints during personAssication

### DIFF
--- a/Pose2Sim/personAssociation.py
+++ b/Pose2Sim/personAssociation.py
@@ -83,7 +83,9 @@ def persons_combinations(json_files_framef):
     for c in range(n_cams):
         try:
             with open(json_files_framef[c], 'r') as js:
-                nb_persons_per_cam += [len(json.load(js)['people'])]
+                people = json.load(js)['people']
+                people = [p for p in people if not all(np.isnan(p["pose_keypoints_2d"][::3]))]
+                nb_persons_per_cam += [len(people)]
         except:
             nb_persons_per_cam += [0]
     


### PR DESCRIPTION
In some cases, poseEstimation returns entries with only NaN values in the output file. This causes unnecessary and time-consuming calculations in personAssociation when generating and testing all possible person combinations.

This PR updates the person_combinations() function to exclude entries where all pose_keypoints_2d are NaN, by adding a check to filter out persons (with all NaN keypoints) before processing.