### PR TITLE
Allow NaN representation in TRC exports

### DIFF
--- a/Pose2Sim/filtering.py
+++ b/Pose2Sim/filtering.py
@@ -743,7 +743,7 @@ def filter_all(config_dict):
                 Q_filt.insert(0, 'Frame#', frames_col)
                 Q_filt.insert(1, 'Time', time_col)
                 # Q_filt = Q_filt.fillna(' ')
-                Q_filt.to_csv(trc_o, sep='\t', index=False, header=None, lineterminator='\n')
+                Q_filt.to_csv(trc_o, sep='\t', index=False, header=None, lineterminator='\n', na_rep='NaN')
 
             # Save c3d
             if make_c3d:

--- a/Pose2Sim/triangulation.py
+++ b/Pose2Sim/triangulation.py
@@ -210,7 +210,7 @@ def make_trc(config_dict, Q, keypoints_names, id_person=-1):
     trc_path = os.path.realpath(os.path.join(pose3d_dir, trc_f))
     with open(trc_path, 'w') as trc_o:
         [trc_o.write(line+'\n') for line in header_trc]
-        Q.to_csv(trc_o, sep='\t', index=True, header=None, lineterminator='\n')
+        Q.to_csv(trc_o, sep='\t', index=True, header=None, lineterminator='\n', na_rep='NaN')
 
     return trc_path
 


### PR DESCRIPTION
Updated the to_csv calls in filtering.py and triangulation.py to use na_rep='NaN' when exporting TRC files. This ensures missing values are consistently represented as 'NaN' in the output files.