### PR TITLE
Add continue_on_error option for batch processing resilience

### DIFF
--- a/Pose2Sim/Demo_Batch/Config.toml
+++ b/Pose2Sim/Demo_Batch/Config.toml
@@ -33,6 +33,8 @@ frame_range = 'auto' # 'auto', 'all', or range like [10,300]. If 'auto', will tr
 exclude_from_batch = [] # List of trials to be excluded from batch analysis, ['<participant_dir/trial_dir>', 'etc'].
 # e.g. ['S00_P00_Participant/S00_P00_T00_StaticTrial', 'S00_P00_Participant/S00_P00_T01_BalancingTrial']
 
+continue_on_error = true # If true, skip failing trials and log exceptions
+
 
 [pose]
 vid_img_extension = 'mp4' # any video or image extension


### PR DESCRIPTION
This PR introduces a continue_on_error parameter in Config.toml to skip failing trials and log exceptions instead of halting execution. Major processing steps (poseEstimation, synchronization, personAssociation, triangulation, filtering, markerAugmentation, kinematics) are wrapped in try-catch blocks. If enabled, the pipeline continues unless a critical failure occurs. Errors are logged with trial details for debugging.

Key changes:
- Introduce `continue_on_error` parameter to skip failing trials and log exceptions
- Wrap major processing steps in try-catch blocks with configurable error handling
- Ensure pipeline continues execution unless critical failure occurs